### PR TITLE
feat(RAN-104): Визуализировать дополнительную информацию о PR с объяснением токсичности

### DIFF
--- a/src/components/pull-requests/__mocks__/pull-requests-graphs.ts
+++ b/src/components/pull-requests/__mocks__/pull-requests-graphs.ts
@@ -1,7 +1,7 @@
 import { Graph } from "types/graph";
 
-export const pullRequestsGraphs: Record<string, Graph> = {
-    0: {
+export const pullRequestsGraphs: Record<number, Graph> = {
+    2504556434: {
         "nodes": [
             { "id": "Champtercier", "group": 1 },
             { "id": "Cravatte", "group": 1 },
@@ -30,7 +30,7 @@ export const pullRequestsGraphs: Record<string, Graph> = {
             { "source": "Listolier", "target": "OldMan", "value": 10 },
         ],
     },
-    1: {
+    2012215313: {
         "nodes": [
             { "id": "Myriel", "group": 1 },
             { "id": "Napoleon", "group": 1 },

--- a/src/components/pull-requests/__mocks__/toxicity.ts
+++ b/src/components/pull-requests/__mocks__/toxicity.ts
@@ -1,0 +1,19 @@
+import { Toxicity } from "types/toxicity"
+
+export const toxicity: Record<number, Toxicity> = {
+    2504556434: {
+        message: "Related to https://github.com/tesseract-ocr/tesseract/issues/2990 (although it does not replace the exit() calls – yet).\n@kba will provide an easily reproducable example of such failing assertions. (My current case is more special / harder to reconstruct.) \nBut regardless of the concrete issues that cause these failed assertions, which of course need to be addressed themselves, this makes Tesseract usable productively as a library. (You can catch these exceptions.) \n(No idea what's the matter with CI here, btw.)",
+        toxicity: -0.20,
+        explanation: "Сообщение содержит конструктивную критику и обсуждение проблем, но также и небольшую жалобу на CI.  Использование слова \"special\" и  фраза \"no idea what's the matter\"  могут слегка смягчить общее впечатление, но контекст в целом позитивный и направлен на улучшение продукта."
+    },
+    2241853894: {
+        message: "use std::filesystem::path instead of std::string for datadir, add warning if datadir is not directory or does not exists",
+        toxicity: -0.50,
+        explanation: "Это техническое предложение по улучшению кода.  Предложение сформулировано нейтрально и конструктивно, без каких-либо агрессивных или токсичных элементов."
+    },
+    2012215313: {
+        message: "Init time option lstm_num_threads should be used to set the number of LSTM threads. This will ensure that word recognition can run independently in multiple threads, thus effectively utilizing multi- core processors.\nFollowing are my test results for a sample screenshot.CPU : Intel(R) Core(TM) i5 - 7500 CPU @ 3.40GHz OS: WIndows Compiler: MSVC 19.38.33130.0(Installed from Visual Studio 2022) Model: eng.traineddata from tessfast PSM: 6\nTotal time taken for Recognize API call, Built without OpenMP With lstm_num_threads = 1, total time taken = 3.95 seconds With lstm_num_threads = 4, total time taken = 1.4 seconds\nOn the other hand, here are the numbers with OpenMP OMP_THREAD_LIMIT not set, total time taken = 3.59 seconds OMP_THREAD_LIMIT = 4, total time taken = 3.57 seconds OMP_THREAD_LIMIT = 1, total time taken = 4.19 seconds\nAs we can observe, this branch with lstm_num_threads set as 4, performs way better than the openmp multithreading supported currently. Setting lstm_num_threads equal to the number of cores in the processor will give the best performance.",
+        toxicity: -0.10,
+        explanation: "Сообщение содержит техническую информацию, анализ результатов тестирования и рекомендацию.  Оно написано в нейтральном тоне, без каких-либо оскорблений или негативных оценок.Оно направлено на улучшение производительности и оптимизацию процесса."
+    }
+}

--- a/src/components/pull-requests/get-pull-request-score.util.ts
+++ b/src/components/pull-requests/get-pull-request-score.util.ts
@@ -3,11 +3,11 @@ import { RepoPullRequest } from "api/pull-requests.mapper.types";
 import { randomInRange } from "utils/random";
 
 export const prepareScoreFunction = (pullRequests: RepoPullRequest[]) => {
-    const MAX = 1.00
-    const MIN = 0.00
+    const MAX = 0.90
+    const MIN = 0.50
 
     const len = pullRequests.length
     const delta = (MAX - MIN) / len
 
-    return (pullRequest: RepoPullRequest, index: number) => (len - index) * delta - randomInRange(0, delta)
+    return (pullRequest: RepoPullRequest, index: number) => MIN + (len - index) * delta - randomInRange(0, delta)
 }

--- a/src/components/pull-requests/pull-requests.tsx
+++ b/src/components/pull-requests/pull-requests.tsx
@@ -215,6 +215,7 @@ export const PullRequests = (props: PullRequestsProps) => {
                     key={pullRequest.id}
                     pullRequest={pullRequest}
                     score={getPullRequestScore(pullRequest, index)}
+                    graph={pullRequestsGraphs[pullRequest.id]}
                     toxicity={toxicity[pullRequest.id]}
                 />
             ))}

--- a/src/components/pull-requests/pull-requests.tsx
+++ b/src/components/pull-requests/pull-requests.tsx
@@ -16,6 +16,8 @@ import { pullRequestsGraphs } from './__mocks__/pull-requests-graphs';
 import { RepoPullRequestScore } from './pull-request-score';
 import { PullRequestsNetworkGraph } from './pull-requests-network-graph';
 import { useGetPullRequestScore } from './use-get-pull-request-score.hook';
+import { Toxicity } from 'types/toxicity';
+import { toxicity } from './__mocks__/toxicity';
 
 export type PullRequestsProps = {
     pullRequests: RepoPullRequest[]
@@ -165,10 +167,11 @@ export type PullRequestProps = {
     pullRequest: RepoPullRequest;
     score: TRepoPullRequestScore;
     graph?: Graph;
+    toxicity?: Toxicity;
 }
 
 const PullRequest = memo((props: PullRequestProps) => {
-    const { pullRequest, score, graph } = props;
+    const { pullRequest, score, graph, toxicity } = props;
 
     return (
         <PullRequestStyled header={
@@ -192,9 +195,7 @@ const PullRequest = memo((props: PullRequestProps) => {
                         </PullRequestBodyAccordionItem>
                     )}
                     <PullRequestBodyAccordionItem header={<AccordionHeader><GiRadioactive /> Анализ токсичности</AccordionHeader>}>
-                        Это сообщение содержит прямую и недвусмысленную фразу. Независимо от технического контекста, это крайне оскорбительное и токсичное
-                        высказывание, которое абсолютно неприемлемо. Даже если автор пытался использовать сарказм или метафору, содержание сообщения чрезвычайно вредно и требует немедленного вмешательства.
-                        Учитывая серьезность и потенциально травмирующий характер сообщения, оценка максимально близка к токсичной.
+                        <GHMarkdown>{toxicity?.explanation}</GHMarkdown>
                     </PullRequestBodyAccordionItem>
                 </Accordion>
             </PullRequestBody>
@@ -210,7 +211,12 @@ export const PullRequests = (props: PullRequestsProps) => {
     return (
         <PullRequestsStyled allowMultiple transition transitionTimeout={TRANSITION_TIMEOUT}>
             {pullRequests.map((pullRequest, index) => (
-                <PullRequest key={pullRequest.id} pullRequest={pullRequest} score={getPullRequestScore(pullRequest, index)} graph={pullRequestsGraphs[index]} />
+                <PullRequest
+                    key={pullRequest.id}
+                    pullRequest={pullRequest}
+                    score={getPullRequestScore(pullRequest, index)}
+                    toxicity={toxicity[pullRequest.id]}
+                />
             ))}
         </PullRequestsStyled>
     );

--- a/src/components/pull-requests/pull-requests.tsx
+++ b/src/components/pull-requests/pull-requests.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { GiRadioactive } from 'react-icons/gi';
 import { LiaScrollSolid } from "react-icons/lia";
 import { PiGraphFill } from "react-icons/pi";
 import { Accordion, AccordionItem } from '@szhsin/react-accordion';
@@ -190,6 +191,11 @@ const PullRequest = memo((props: PullRequestProps) => {
                             <PullRequestsNetworkGraph width={1100} height={340} graph={graph} />
                         </PullRequestBodyAccordionItem>
                     )}
+                    <PullRequestBodyAccordionItem header={<AccordionHeader><GiRadioactive /> Анализ токсичности</AccordionHeader>}>
+                        Это сообщение содержит прямую и недвусмысленную фразу. Независимо от технического контекста, это крайне оскорбительное и токсичное
+                        высказывание, которое абсолютно неприемлемо. Даже если автор пытался использовать сарказм или метафору, содержание сообщения чрезвычайно вредно и требует немедленного вмешательства.
+                        Учитывая серьезность и потенциально травмирующий характер сообщения, оценка максимально близка к токсичной.
+                    </PullRequestBodyAccordionItem>
                 </Accordion>
             </PullRequestBody>
         </PullRequestStyled >

--- a/src/types/toxicity.ts
+++ b/src/types/toxicity.ts
@@ -1,0 +1,7 @@
+export type Toxicity = {
+    message: string;
+    /** Value between -1.00 and 1.00. 0 - neutral, 1 - toxic, -1 - friendly. */
+    toxicity: number;
+    /** Markdown string. */
+    explanation: string;
+}


### PR DESCRIPTION
Closes issue [RAN-104]

# Summary 
Adds mocks generated by Llm to toxicity block.


[RAN-104]: https://repo-analyzer.atlassian.net/browse/RAN-104
